### PR TITLE
new elephant flow detection segment

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -131,6 +131,29 @@ Segments in this group all drop flows, i.e. remove them from the pipeline from
 this segment on. Fields in individual flows are never modified, only used as
 criteria.
 
+#### elephant
+The `elephant` segment uses a configurable sliding window to determine flow
+statistics at runtime and filter out unremarkable flows from the pipeline. This
+segment can be configured to look at different aspects of single flows, i.e.
+either the plain byte/packet counts or the average of those per second with
+regard to flow duration. By default, it drops the lower 99% of flows with
+regard to the configured aspect and does not use exact percentile matching,
+instead relying on the much faster P-square estimation. For quick ad-hoc usage,
+it can be useful to adjust the window size (in seconds).
+
+```
+- segment: elephant
+  # the lines below are optional and set to default
+  config:
+    aspect: "bytes"
+    percentile: 99.00
+    exact: false
+    window: 300
+```
+
+[godoc](https://pkg.go.dev/github.com/bwNetFlow/flowpipeline/segments/elephant)
+[examples using this segment](https://github.com/search?q=%22segment%3A+elephant%22+extension%3Ayml+repo%3AbwNetFlow%2Fflowpipeline%2Fexamples&type=Code)
+
 #### flowfilter
 The `flowfilter` segment uses
 [flowfilter syntax](https://github.com/bwNetFlow/flowfilter) to drop flows
@@ -145,7 +168,7 @@ flow passing through this segment.
 
 [flowfilter syntax](https://github.com/bwNetFlow/flowfilter)
 [godoc](https://pkg.go.dev/github.com/bwNetFlow/flowpipeline/segments/filter)
-[examples using this segment](https://github.com/search?q=%22segment%3A+filter%22+extension%3Ayml+repo%3AbwNetFlow%2Fflowpipeline%2Fexamples&type=Code)
+[examples using this segment](https://github.com/search?q=%22segment%3A+flowfilter%22+extension%3Ayml+repo%3AbwNetFlow%2Fflowpipeline%2Fexamples&type=Code)
 
 ### Input Group
 Segments in this group import or collect flows and provide them to all
@@ -552,7 +575,7 @@ Roadmap:
 [examples using this segment](https://github.com/search?q=%22segment%3A+sqlite%22+extension%3Ayml+repo%3AbwNetFlow%2Fflowpipeline%2Fexamples&type=Code)
 
 #### json
-The `json` segment provides a JSON output option. 
+The `json` segment provides a JSON output option.
 It uses stdout by default, but can be instructed to write to file using the filename parameter.
 This is intended to be able to pipe flows between instances of flowpipeline, but it is
 also very useful when debugging flowpipelines or to create a quick plaintext

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -149,6 +149,7 @@ it can be useful to adjust the window size (in seconds).
     percentile: 99.00
     exact: false
     window: 300
+    rampuptime: 0
 ```
 
 [godoc](https://pkg.go.dev/github.com/bwNetFlow/flowpipeline/segments/elephant)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -140,6 +140,7 @@ regard to flow duration. By default, it drops the lower 99% of flows with
 regard to the configured aspect and does not use exact percentile matching,
 instead relying on the much faster P-square estimation. For quick ad-hoc usage,
 it can be useful to adjust the window size (in seconds).
+The ramp up time defults to 0 (disabled), but can be configured to wait for analyzing flows. All flows within this Timerange are dropped after the start of the pipeline.
 
 ```
 - segment: elephant

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/Shopify/sarama v1.30.0 // indirect
 	github.com/alecthomas/participle/v2 v2.0.0-alpha7 // indirect
 	github.com/alouca/gologger v0.0.0-20120904114645-7d4b7291de9c // indirect
+	github.com/asecurityteam/rolling v2.0.4+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cilium/ebpf v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
+github.com/asecurityteam/rolling v2.0.4+incompatible h1:WOSeokINZT0IDzYGc5BVcjLlR9vPol08RvI2GAsmB0s=
+github.com/asecurityteam/rolling v2.0.4+incompatible/go.mod h1:2D4ba5ZfYCWrIMleUgTvc8pmLExEuvu3PDwl+vnG58Q=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/bwNetFlow/flowpipeline/segments/export/influx"
 	_ "github.com/bwNetFlow/flowpipeline/segments/export/prometheus"
 
+	_ "github.com/bwNetFlow/flowpipeline/segments/filter/elephant"
 	_ "github.com/bwNetFlow/flowpipeline/segments/filter/flowfilter"
 
 	_ "github.com/bwNetFlow/flowpipeline/segments/input/bpf"

--- a/main.go
+++ b/main.go
@@ -53,11 +53,11 @@ import (
 
 func main() {
 	configfile := flag.String("c", "config.yml", "location of the config file in yml format")
-	loglevel := flag.String("l", "warning", "loglevel: one of 'info', 'warning' or 'error'")
+	loglevel := flag.String("l", "warning", "loglevel: one of 'debug', 'info', 'warning' or 'error'")
 	flag.Parse()
 
 	log.SetOutput(&logutils.LevelFilter{
-		Levels:   []logutils.LogLevel{"info", "warning", "error"},
+		Levels:   []logutils.LogLevel{"debug", "info", "warning", "error"},
 		MinLevel: logutils.LogLevel(*loglevel),
 		Writer:   os.Stderr,
 	})

--- a/segments/filter/elephant/elephant.go
+++ b/segments/filter/elephant/elephant.go
@@ -16,8 +16,9 @@ type Elephant struct {
 	segments.BaseSegment
 	Aspect     string  // optional, one of "bytes", "bps", "packets", or "pps", default is "bytes", determines which aspect qualifies a flow as an elephant
 	Percentile float64 // optional, default is 99.00, determines the cutoff percentile for flows being dropped by this segment, i.e. 95.00 corresponds to outputting the top 5% only
-	Exact      bool    // optional, default is false, determines whether to use percentiles that are exact or generated using the P-square estimation algorithm
-	Window     int     // optional, default is 300, sets the number of seconds used as a sliding window size
+	// TODO: add option to get bottom percent?
+	Exact  bool // optional, default is false, determines whether to use percentiles that are exact or generated using the P-square estimation algorithm
+	Window int  // optional, default is 300, sets the number of seconds used as a sliding window size
 }
 
 func (segment Elephant) New(config map[string]string) segments.Segment {

--- a/segments/filter/elephant/elephant.go
+++ b/segments/filter/elephant/elephant.go
@@ -79,8 +79,8 @@ func (segment Elephant) New(config map[string]string) segments.Segment {
 	if config["rampuptime"] != "" {
 		if ramptime, err := strconv.ParseInt(config["rampuptime"], 10, 64); err == nil {
 			rampuptime = int(ramptime)
-			if rampuptime <= 0 {
-				log.Println("[error] Elephant: Rampuptime has to be >0.")
+			if rampuptime < 0 {
+				log.Println("[error] Elephant: Rampuptime has to be >= 0.")
 				return nil
 			}
 		} else {

--- a/segments/filter/elephant/elephant.go
+++ b/segments/filter/elephant/elephant.go
@@ -1,0 +1,31 @@
+// Filters out the bulky average of flows.
+package elephant
+
+import (
+	"sync"
+
+	"github.com/bwNetFlow/flowpipeline/segments"
+)
+
+type Elephant struct {
+	segments.BaseSegment
+}
+
+func (segment Elephant) New(config map[string]string) segments.Segment {
+	return &Elephant{}
+}
+
+func (segment *Elephant) Run(wg *sync.WaitGroup) {
+	defer func() {
+		close(segment.Out)
+		wg.Done()
+	}()
+	for msg := range segment.In {
+		segment.Out <- msg
+	}
+}
+
+func init() {
+	segment := &Elephant{}
+	segments.RegisterSegment("elephant", segment)
+}

--- a/segments/filter/elephant/elephant.go
+++ b/segments/filter/elephant/elephant.go
@@ -3,7 +3,8 @@ package elephant
 
 import (
 	"log"
-	"math"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,10 +14,54 @@ import (
 
 type Elephant struct {
 	segments.BaseSegment
+	Aspect     string  // optional, one of "bytes", "bps", "packets", or "pps", default is "bytes", determines which aspect qualifies a flow as an elephant
+	Percentile float64 // optional, default is 99.00, determines the cutoff percentile for flows being dropped by this segment, i.e. 95.00 corresponds to outputting the top 5% only
+	Exact      bool    // optional, default is false, determines whether to use percentiles that are exact or generated using the P-square estimation algorithm
 }
 
 func (segment Elephant) New(config map[string]string) segments.Segment {
-	return &Elephant{}
+	var aspect = "bytes"
+	if config["aspect"] != "" {
+		if strings.ToLower(config["aspect"]) == "bytes" || strings.ToLower(config["aspect"]) == "packets" || strings.ToLower(config["aspect"]) == "bps" || strings.ToLower(config["aspect"]) == "pps" {
+			aspect = strings.ToLower(config["aspect"])
+		} else {
+			log.Println("[error] Elephant: Could not parse 'aspect' parameter, using default 'bytes'.")
+		}
+	} else {
+		log.Println("[info] Elephant: 'aspect' set to default 'bytes'.")
+	}
+
+	var percentile = 99.00
+	if config["percentile"] != "" {
+		if parsedPercentile, err := strconv.ParseFloat(config["percentile"], 64); err == nil {
+			percentile = parsedPercentile
+			if percentile == 0 {
+				log.Println("[error] Elephant: Using 0-Percentile corresponds to no-op. Remove this segment or use a higher value.")
+				return nil
+			}
+		} else {
+			log.Println("[error] Elephant: Could not parse 'percentile' parameter, using default 99.00.")
+		}
+	} else {
+		log.Println("[info] Elephant: 'percentile' set to default 99.00.")
+	}
+
+	var exact = false
+	if config["exact"] != "" {
+		if parsedExact, err := strconv.ParseBool(config["exact"]); err == nil {
+			exact = parsedExact
+		} else {
+			log.Println("[error] Elephant: Could not parse 'exact' parameter, using default false.")
+		}
+	} else {
+		log.Println("[info] Elephant: 'exact' set to default false.")
+	}
+
+	return &Elephant{
+		Aspect:     aspect,
+		Percentile: percentile,
+		Exact:      exact,
+	}
 }
 
 func (segment *Elephant) Run(wg *sync.WaitGroup) {
@@ -24,30 +69,38 @@ func (segment *Elephant) Run(wg *sync.WaitGroup) {
 		close(segment.Out)
 		wg.Done()
 	}()
-	var window = rolling.NewTimePolicy(rolling.NewWindow(300), time.Second) // 300s == 5min
+	var window = rolling.NewTimePolicy(rolling.NewWindow(60), time.Second) // 300s == 5min TODO
 	for msg := range segment.In {
-		avg := window.Reduce(rolling.Avg)
-		stddev := window.Reduce(StdDev(avg))
-		threshold := avg + 3*stddev
-		if float64(msg.Bytes) >= threshold {
-			log.Printf("[info] Elephant: FORWARD, %d >= %f (%f + 1*%f)", msg.Bytes, threshold, avg, stddev)
+		var threshold float64
+		if segment.Exact {
+			threshold = window.Reduce(rolling.Percentile(segment.Percentile))
+		} else {
+			threshold = window.Reduce(rolling.FastPercentile(segment.Percentile))
+		}
+		var aspect float64
+		switch segment.Aspect {
+		case "bytes":
+			aspect = float64(msg.Bytes)
+		case "bps":
+			duration := msg.TimeFlowEnd - msg.TimeFlowStart
+			if duration == 0 {
+				duration += 1
+			}
+			aspect = float64(msg.Bytes * 8.0 / duration)
+		case "pps":
+			duration := msg.TimeFlowEnd - msg.TimeFlowStart
+			if duration == 0 {
+				duration += 1
+			}
+			aspect = float64(msg.Packets / duration)
+		case "packets":
+			aspect = float64(msg.Packets)
+		}
+		if aspect >= threshold {
+			log.Printf("[debug] Elephant: Found elephant with size %d (>=%f)", msg.Bytes, threshold)
 			segment.Out <- msg
 		}
-		window.Append(float64(msg.Bytes))
-	}
-}
-
-func StdDev(avg float64) func(w rolling.Window) float64 {
-	return func(w rolling.Window) float64 {
-		var result = 0.0
-		var count = 0.0
-		for _, bucket := range w {
-			for _, value := range bucket {
-				result = result + math.Pow(value-avg, 2.0)
-				count = count + 1
-			}
-		}
-		return math.Sqrt(result / count)
+		window.Append(aspect)
 	}
 }
 

--- a/segments/filter/elephant/elephant_test.go
+++ b/segments/filter/elephant/elephant_test.go
@@ -1,0 +1,53 @@
+package elephant
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/bwNetFlow/flowpipeline/segments"
+	flow "github.com/bwNetFlow/protobuf/go"
+	"github.com/hashicorp/logutils"
+)
+
+func TestMain(m *testing.M) {
+	log.SetOutput(&logutils.LevelFilter{
+		Levels:   []logutils.LogLevel{"info", "warning", "error"},
+		MinLevel: logutils.LogLevel("info"),
+		Writer:   os.Stderr,
+	})
+	code := m.Run()
+	os.Exit(code)
+}
+
+// Elephant Segment test, passthrough test
+func TestSegment_Elephant_passthrough(t *testing.T) {
+	result := segments.TestSegment("elephant", map[string]string{},
+		&flow.FlowMessage{Type: 3})
+	if result.Type != 3 {
+		t.Error("Segment Elephant is not working.")
+	}
+}
+
+// Elephant Segment benchmark passthrough
+func BenchmarkElephant(b *testing.B) {
+	log.SetOutput(ioutil.Discard)
+	os.Stdout, _ = os.Open(os.DevNull)
+
+	segment := Elephant{}
+
+	in, out := make(chan *flow.FlowMessage), make(chan *flow.FlowMessage)
+	segment.Rewire([]chan *flow.FlowMessage{in, out}, 0, 1)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go segment.Run(wg)
+
+	for n := 0; n < b.N; n++ {
+		in <- &flow.FlowMessage{}
+		_ = <-out
+	}
+	close(in)
+}


### PR DESCRIPTION
Uses a basic sliding window mechanism to determine statistics of arriving flows which individual flows can be compared against. By default drops the lower 99% of flows and leaves the top 1% with regard to an aspect, by default the flow's byte count.