### PR TITLE
implement graceful shutdown for parent pipelines to use in segments

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -371,12 +371,15 @@ set forth by the universities.
 The `stdin` segment reads JSON encoded flows from stdin or a given file and introduces this
 into the pipeline. This is intended to be used in conjunction with the `json`
 segment, which allows flowpipelines to be piped into each other.
+This segment can also read files created with the `json` segment.
+The `closeoneof` parameter can therefore be used to gracefully terminate the pipeline after reading the file.
 
-```
+```yaml
 - segment: stdin
   # the lines below are optional and set to default
   config:
     filename: ""
+    closeoneof: false
 ```
 
 [godoc](https://pkg.go.dev/github.com/bwNetFlow/flowpipeline/segments/input/stdin)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -372,14 +372,14 @@ The `stdin` segment reads JSON encoded flows from stdin or a given file and intr
 into the pipeline. This is intended to be used in conjunction with the `json`
 segment, which allows flowpipelines to be piped into each other.
 This segment can also read files created with the `json` segment.
-The `closeoneof` parameter can therefore be used to gracefully terminate the pipeline after reading the file.
+The `eofcloses` parameter can therefore be used to gracefully terminate the pipeline after reading the file.
 
 ```yaml
 - segment: stdin
   # the lines below are optional and set to default
   config:
     filename: ""
-    closeoneof: false
+    eofcloses: false
 ```
 
 [godoc](https://pkg.go.dev/github.com/bwNetFlow/flowpipeline/segments/input/stdin)

--- a/segments/input/bpf/bpf.go
+++ b/segments/input/bpf/bpf.go
@@ -5,7 +5,6 @@ package bpf
 
 import (
 	"log"
-	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -101,7 +100,8 @@ func (segment *Bpf) Run(wg *sync.WaitGroup) {
 	err := segment.dumper.Start()
 	if err != nil {
 		log.Printf("[error] Bpf: error starting up BPF dumping: %s", err)
-		os.Exit(1)
+		segment.ShutdownParentPipeline()
+		return
 	}
 	segment.exporter.Start(segment.dumper.SamplerAddress)
 	go segment.exporter.ConsumeFrom(segment.dumper.Packets())

--- a/segments/input/stdin/stdin.go
+++ b/segments/input/stdin/stdin.go
@@ -38,13 +38,13 @@ func (segment StdIn) New(config map[string]string) segments.Segment {
 		}
 		filename = config["filename"]
 		if config["eofcloses"] != "" {
-			if parsedClose, err := strconv.ParseBool(config["closeoneof"]); err == nil {
+			if parsedClose, err := strconv.ParseBool(config["eofcloses"]); err == nil {
 				eofCloses = parsedClose
 			} else {
-				log.Println("[error] StdIn: Could not parse 'closeoneof' parameter, using default false.")
+				log.Println("[error] StdIn: Could not parse 'eofcloses' parameter, using default false.")
 			}
 		} else {
-			log.Println("[info] StdIn: 'closeoneof' set to default false.")
+			log.Println("[info] StdIn: 'eofcloses' set to default false.")
 		}
 	} else {
 		file = os.Stdin

--- a/segments/input/stdin/stdin.go
+++ b/segments/input/stdin/stdin.go
@@ -5,6 +5,7 @@ package stdin
 import (
 	"bufio"
 	"log"
+	"strconv"
 
 	"github.com/bwNetFlow/flowpipeline/pb"
 	"github.com/bwNetFlow/flowpipeline/segments"
@@ -18,7 +19,8 @@ type StdIn struct {
 	segments.BaseSegment
 	scanner *bufio.Scanner
 
-	FileName string // optional, default is empty which means read from stdin
+	FileName   string // optional, default is empty which means read from stdin
+	CloseOnEOF bool   // optional, default is fals. Closes Pipeleine gracefully after input file was read
 }
 
 func (segment StdIn) New(config map[string]string) segments.Segment {
@@ -27,6 +29,7 @@ func (segment StdIn) New(config map[string]string) segments.Segment {
 	var filename string = "stdout"
 	var file *os.File
 	var err error
+	var closeOnEOF bool = false
 	if config["filename"] != "" {
 		file, err = os.Open(config["filename"])
 		if err != nil {
@@ -34,6 +37,15 @@ func (segment StdIn) New(config map[string]string) segments.Segment {
 			return nil
 		}
 		filename = config["filename"]
+		if config["closeoneof"] != "" {
+			if parsedClose, err := strconv.ParseBool(config["closeoneof"]); err == nil {
+				closeOnEOF = parsedClose
+			} else {
+				log.Println("[error] StdIn: Could not parse 'closeoneof' parameter, using default false.")
+			}
+		} else {
+			log.Println("[info] StdIn: 'closeoneof' set to default false.")
+		}
 	} else {
 		file = os.Stdin
 		log.Println("[info] StdIn: 'filename' unset, using stdIn.")
@@ -41,6 +53,7 @@ func (segment StdIn) New(config map[string]string) segments.Segment {
 	newsegment.scanner = bufio.NewScanner(file)
 
 	newsegment.FileName = filename
+	newsegment.CloseOnEOF = closeOnEOF
 
 	return newsegment
 }
@@ -53,10 +66,15 @@ func (segment *StdIn) Run(wg *sync.WaitGroup) {
 	fromStdin := make(chan []byte)
 	go func() {
 		for {
-			segment.scanner.Scan()
+			scan := segment.scanner.Scan()
 			if err := segment.scanner.Err(); err != nil {
 				log.Printf("[warning] StdIn: Skipping a flow, could not read line from stdin: %v", err)
 				continue
+			}
+			if segment.CloseOnEOF && !scan && segment.scanner.Err() == nil {
+				log.Printf("[info] Reached eof of %s, closing pipeline", segment.FileName)
+				segment.ShutdownParentPipeline()
+				return
 			}
 			if len(segment.scanner.Text()) == 0 {
 				continue

--- a/segments/output/kafkaproducer/kafkaproducer.go
+++ b/segments/output/kafkaproducer/kafkaproducer.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"log"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -187,7 +186,8 @@ func (segment *KafkaProducer) Run(wg *sync.WaitGroup) {
 				suffix = field.Interface().(string)
 			default:
 				log.Println("[error] KafkaProducer: TopicSuffix must be of type uint or string.")
-				os.Exit(1)
+				segment.ShutdownParentPipeline()
+				return
 			}
 			producer.Input() <- &sarama.ProducerMessage{
 				Topic: segment.Topic + "-" + suffix,

--- a/segments/pass/pass.go
+++ b/segments/pass/pass.go
@@ -25,7 +25,7 @@ func (segment Pass) New(config map[string]string) segments.Segment {
 // The main goroutine of any Segment. Any Run method must:
 // 1. close(segment.Out) when the In channel is closed by the previous segment or the Pipeline itself
 // 2. call wg.Done() before exiting
-// 3. if exiting for any other reason, use os.Exit or just continue to pass from In to Out
+// 3. if exiting for any other reason, use segment.ShutdownParentPipeline() or just continue to pass from In to Out
 //
 // Usually, when using a range over In in combination with below defer, nothing
 // will go wrong. However, some segments have a legitimate use case for using


### PR DESCRIPTION
 use ShutdownParentPipeline() instead of exit() in segments to terminate the parentpipeline gracefully.
Example usage is shown inthe stdin segment to be able to configure a graceful termination of the pipeline after a file was read an reached EOF.

This funcion also replaces any need of os.Exit() in other segments.