### PR TITLE
segment toptalkers_metrics: fixed logic to evaluate thresholds

### DIFF
--- a/segments/analysis/toptalkers_metrics/toptalkers_metrics.go
+++ b/segments/analysis/toptalkers_metrics/toptalkers_metrics.go
@@ -163,7 +163,7 @@ func (record *Record) tick(thresholdBuckets int, bucketDuration int, thresholdBp
 	}
 	bps := uint64(float64(sumBytes*8) / float64(bucketDuration*thresholdBuckets))
 	pps := uint64(float64(sumPackets) / float64(bucketDuration*thresholdBuckets))
-	if (bps > thresholdBps) || (pps > thresholdPps) {
+	if (bps > thresholdBps) && (pps > thresholdPps) {
 		record.aboveThreshold.Store(true)
 	} else {
 		record.aboveThreshold.Store(false)


### PR DESCRIPTION
Thresholds are by default set to `0`, so it makes more sense that both threshold checks (bps and pps) must be `true`. This allows to only set one threshold (e.g. just `thresholdbps: 10000`) and the traffic only needs to exceed the set threshold, which is way more intuitive.